### PR TITLE
docs(conference): add React advanced to the conference list

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ From Angular and React to WebAssembly; from Progressive Web Apps to JAMstack –
 **City and State**: Munich<br>
 **Country**: Germany
 
+[React Advanced](https://reactadvanced.com/)
+
+A conference about modern web development with React, React Native, GraphQL and TypeScript.Get a chance to connect with the global network of field experts and explore react.js.<br>
+**City and State**: London<br>
+**Country**: England
+
 ## Vue
 
 [Vue.js Live](https://vuejslive.com/)

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ From Angular and React to WebAssembly; from Progressive Web Apps to JAMstack –
 
 [React Advanced](https://reactadvanced.com/)
 
-A conference about modern web development with React, React Native, GraphQL and TypeScript.Get a chance to connect with the global network of field experts and explore react.js.<br>
+A conference about modern web development with React, React Native, GraphQL and TypeScript. Get a chance to connect with the global network of field experts and explore React.js.<br>
 **City and State**: London<br>
 **Country**: England
 


### PR DESCRIPTION
## Adding a conference
- [x] Suggestion is not a duplicate
- [x] Suggestion is under the proper category
- [x] Link to conference is included 
- [x] Name of conference is included
- [x] Name and link are spelled correctly

<!---
## Adding a category
- [ ] Category is not a duplicate
- [ ] Category is spelled properly
--->
